### PR TITLE
API changes to spins and cogs

### DIFF
--- a/app
+++ b/app
@@ -7,7 +7,7 @@ popd
 #
 # Networking
 #
-python -m solent.eng.scenarios
+#python -m solent.eng.scenarios
 
 #
 # Console
@@ -26,7 +26,7 @@ python -m solent.eng.scenarios
 #
 #python -m solent.draft.draw
 #python -m solent.draft.gollop_box
-#python -m solent.draft.gruel_server_sandbox
+python -m solent.draft.gruel_server_sandbox
 #python -m solent.draft.gruel_client_sandbox --pygame
 #python -m solent.draft.mountain_box --pygame
 #python -m solent.draft.roguebox --pygame

--- a/app
+++ b/app
@@ -7,13 +7,7 @@ popd
 #
 # Networking
 #
-#python -m solent.eng.scenarios
-
-#
-# Console
-#
-#python -m solent.draft.console_demo --curses
-#python -m solent.draft.console_demo --pygame
+python -m solent.eng.scenarios
 
 #
 # Release
@@ -22,23 +16,35 @@ popd
 #python -m solent.release.roguebox_00_weed_the_garden --pygame
 
 #
-# Draft
+# Tools
 #
-#python -m solent.draft.draw
-#python -m solent.draft.gollop_box
-python -m solent.draft.gruel_server_sandbox
-#python -m solent.draft.gruel_client_sandbox --pygame
-#python -m solent.draft.mountain_box --pygame
-#python -m solent.draft.roguebox --pygame
-#python -m solent.draft.turn_based_game --curses
-#python -m solent.draft.turn_based_game --pygame
-
-#python -m solent.draft.oled_ui_demo
-
-#python -m wsrc.build_all
-#python -m solent.draft.wrap_c_code
-
 #python -m solent.tools.qd_listen 127.255.255.255 50000
 #python -m solent.tools.qd_poll 127.255.255.255 50000
 #python -m solent.tools.tclient localhost 5001
+
+#
+# Wrapping C
+#
+#python -m wsrc.build_all
+#python -m solent.draft.wrap_c_code
+
+#
+# Console
+#
+#python -m solent.draft.console_demo --curses
+#python -m solent.draft.console_demo --pygame
+
+#
+# Other drafting
+#
+#python -m solent.draft.demonstrate_line_console
+#python -m solent.draft.draw
+#python -m solent.draft.gollop_box
+#python -m solent.draft.gruel_server_sandbox
+#python -m solent.draft.gruel_client_sandbox --pygame
+#python -m solent.draft.mountain_box --pygame
+#python -m solent.draft.oled_ui_demo
+#python -m solent.draft.roguebox --pygame
+#python -m solent.draft.turn_based_game --curses
+#python -m solent.draft.turn_based_game --pygame
 

--- a/fake/eng/fake_engine.py
+++ b/fake/eng/fake_engine.py
@@ -50,9 +50,9 @@ class FakeEngine:
         self.mtu = 500
     def get_clock(self):
         return self.clock
-    def init_orb(self, spin_h, i_nearcast):
+    def init_orb(self, i_nearcast):
         return orb_new(
-            spin_h=spin_h,
+            spin_h='fake_engine/orb/%s'%uniq(),
             engine=self,
             i_nearcast=i_nearcast)
     def send(self, sid, bb):

--- a/solent/draft/demonstrate_line_console.py
+++ b/solent/draft/demonstrate_line_console.py
@@ -1,0 +1,139 @@
+from solent import SolentQuitException
+from solent.eng import engine_new
+from solent.lc import spin_line_console_new
+from solent.log import log
+
+LC_ADDR = 'localhost'
+LC_PORT = 8200
+
+MTU = 1490
+
+I_NEARCAST = '''
+    i message h
+    i field h
+
+    message init
+
+    message lc_connect
+        field addr
+        field port
+    message lc_condrop
+        field msg
+    message to_lc
+        field s
+
+    message cmd_add
+        field a
+        field b
+    message cmd_echo
+        field s
+    message cmd_quit
+'''
+
+class CogInterpret:
+    def __init__(self, cog_h, orb, engine):
+        self.cog_h = cog_h
+        self.orb = orb
+        self.engine = engine
+    def on_cmd_add(self, a, b):
+        a = int(a)
+        b = int(b)
+        log("%s + %s = %s"%(a, b, a+b))
+    def on_cmd_echo(self, s):
+        self.nearcast.to_lc(
+            s=s)
+    def on_cmd_quit(self):
+        raise SolentQuitException()
+
+class CogLineConsole:
+    def __init__(self, cog_h, orb, engine):
+        self.cog_h = cog_h
+        self.orb = orb
+        self.engine = engine
+        #
+        self.spin_line_console = engine.init_spin(
+            construct=spin_line_console_new,
+            cb_lc_connect=self._on_lc_connect,
+            cb_lc_condrop=self._on_lc_condrop,
+            cb_lc_command=self._on_lc_command)
+    #
+    def on_init(self):
+        self.spin_line_console.start(
+            ip=LC_ADDR,
+            port=LC_PORT)
+    def on_to_lc(self, s):
+        self.spin_line_console.send(
+            msg='%s\n'%s)
+    #
+    def _on_lc_connect(self, cs_lc_connect):
+        addr = cs_lc_connect.addr
+        port = cs_lc_connect.port
+        #
+        self.nearcast.lc_connect(
+            addr=addr,
+            port=port)
+    def _on_lc_condrop(self, cs_lc_condrop):
+        msg = cs_lc_condrop.msg
+        #
+        self.nearcast.lc_condrop(
+            msg=msg)
+    def _on_lc_command(self, cs_lc_command):
+        tokens = cs_lc_command.tokens
+        #
+        def complain(msg):
+            self.spin_line_console.send(
+                msg='%s\n'%msg)
+        #
+        if 0 == len(tokens):
+            pass
+        elif tokens[0] == 'add':
+            if 3 != len(tokens):
+                complain('Usage: add a b')
+                return
+            (_, a, b) = tokens
+            self.nearcast.cmd_add(
+                a=a,
+                b=b)
+        elif tokens[0] == 'echo':
+            if 2 != len(tokens):
+                complain('Usage: echo s')
+                return
+            (_, s) = tokens
+            self.nearcast.cmd_echo(
+                s=s)
+        elif tokens[0] == 'quit':
+            self.nearcast.cmd_quit()
+        else:
+            complain('??')
+            return
+
+class CogBridge:
+    def __init__(self, cog_h, orb, engine):
+        self.cog_h = cog_h
+        self.orb = orb
+        self.engine = engine
+    def nc_init(self):
+        self.nearcast.init()
+
+def main():
+    engine = engine_new(
+        mtu=MTU)
+    try:
+        orb = engine.init_orb(
+            i_nearcast=I_NEARCAST)
+        orb.add_log_snoop()
+        orb.init_cog(CogInterpret)
+        orb.init_cog(CogLineConsole)
+        bridge = orb.init_cog(CogBridge)
+        bridge.nc_init()
+        engine.event_loop()
+    except SolentQuitException:
+        pass
+    except KeyboardInterrupt:
+        pass
+    finally:
+        engine.close()
+
+if __name__ == '__main__':
+    main()
+

--- a/solent/draft/draw.py
+++ b/solent/draft/draw.py
@@ -205,9 +205,7 @@ class CogTerm:
         self.orb = orb
         #
         self.spin_term = None
-    def at_turn(self, activity):
-        self.spin_term.at_turn(
-            activity=activity)
+    #
     def on_init(self, console_type, height, width):
         self.spin_term = self.engine.init_spin(
             construct=spin_term_new,
@@ -314,7 +312,8 @@ class CogDrawGame:
         self.width = None
         self.spin_draw_game = None
         self.tick_t100 = None
-    def at_turn(self, activity):
+    #
+    def orb_turn(self, activity):
         if self.spin_draw_game == None:
             return
     #
@@ -370,7 +369,6 @@ def main():
         engine.default_timeout = 0.05
         #
         orb = engine.init_orb(
-            spin_h=__name__,
             i_nearcast=I_CONTAINMENT_NEARCAST_SCHEMA)
         orb.add_log_snoop()
         orb.init_cog(CogInterpreter)

--- a/solent/draft/gollop_box.py
+++ b/solent/draft/gollop_box.py
@@ -85,16 +85,15 @@ class CogTerm(object):
             rest=0,
             s='Press Q to quit (when selection mode is off).',
             cpair=solent_cpair('green'))
-    def at_turn(self, activity):
+    #
+    def orb_turn(self, activity):
         self.spin_term.write(
             drop=6,
             rest=2,
             s=self.counter,
             cpair=solent_cpair('blue'))
         self.counter += 1
-        #
-        self.spin_term.at_turn(
-            activity=activity)
+    #
     def term_on_keycode(self, keycode):
         self.nearcast.keystroke(
             keycode=keycode)
@@ -112,7 +111,6 @@ def main():
         engine.default_timeout = 0.04
         #
         orb = engine.init_orb(
-            spin_h=__name__,
             i_nearcast=I_NEARCAST_SCHEMA)
         orb.init_cog(CogInterpreter)
         orb.init_cog(CogTerm)

--- a/solent/draft/gruel_client_sandbox.py
+++ b/solent/draft/gruel_client_sandbox.py
@@ -224,10 +224,6 @@ class CogGruelClient:
             construct=spin_gruel_client_new,
             gruel_press=self.gruel_press,
             gruel_puff=self.gruel_puff)
-    def at_turn(self, activity):
-        "Returns a boolean which is True only if there was activity."
-        self.spin_gruel_client.at_turn(
-            activity=activity)
     def on_instruct_gruel_connect(self, server_ip, server_port, password):
         self.spin_gruel_client.order_connect(
             addr=server_ip,
@@ -336,7 +332,7 @@ class CogTerminal:
         self.pane_console = None
         self.pane_announce = None
     #
-    def at_turn(self, activity):
+    def orb_turn(self, activity):
         k = self.console.async_get_keycode()
         if k != None:
             activity.mark(
@@ -344,6 +340,7 @@ class CogTerminal:
                 s='key received')
             self.nearcast.client_keycode(
                 keycode=k)
+    #
     def on_def_console(self, console):
         self.console = console
         self.cgrid = cgrid_new(
@@ -416,7 +413,8 @@ class CogShell:
         self.b_first = True
         self.line_finder = line_finder_new(
             cb_line=self._console_line)
-    def at_turn(self, activity):
+    #
+    def orb_turn(self, activity):
         if self.b_first:
             activity.mark(
                 l=self,
@@ -424,6 +422,7 @@ class CogShell:
             self._console_announce(
                 s='Type "quit" to quit')
             self.b_first = False
+    #
     def on_client_keycode(self, keycode):
         self.line_finder.accept_string(
             s=chr(keycode))
@@ -471,7 +470,6 @@ def wrap_eng(console):
     engine.default_timeout = 0.02
     try:
         orb = engine.init_orb(
-            spin_h=__name__,
             i_nearcast=I_NEARCAST_SCHEMA)
         #
         orb.init_cog(CogGruelClient)

--- a/solent/draft/roguebox.py
+++ b/solent/draft/roguebox.py
@@ -331,9 +331,6 @@ class CogTerm:
         self.orb = orb
         #
         self.spin_term = None
-    def at_turn(self, activity):
-        self.spin_term.at_turn(
-            activity=activity)
     #
     def on_init(self, console_type, console_height, console_width):
         self.spin_term = self.engine.init_spin(
@@ -366,8 +363,6 @@ class CogMenu:
         self.orb = orb
         #
         self.brick_menu = None
-    def close(self):
-        pass
     def on_init(self, console_type, console_height, console_width):
         self.brick_menu = brick_menu_new(
             height=console_height,
@@ -465,9 +460,10 @@ class CogRoguebox:
             width=ROGUEBOX_MFEED_WIDTH,
             cpair_new=solent_cpair('teal'),
             cpair_old=solent_cpair('blue'))
-    def close(self):
+    #
+    def orb_close(self):
         pass
-    def at_turn(self, activity):
+    def orb_turn(self, activity):
         if not self.b_first_game_ready:
             return
         if not self.track_containment_mode.is_focus_on_game():
@@ -595,7 +591,6 @@ def game(console_type):
         #engine.debug_eloop_on()
         #
         orb = engine.init_orb(
-            spin_h=__name__,
             i_nearcast=I_CONTAINMENT_NEARCAST_SCHEMA)
         #orb.add_log_snoop()
         orb.init_cog(CogInterpreter)

--- a/solent/eng/cs.py
+++ b/solent/eng/cs.py
@@ -122,11 +122,11 @@ class CsTcpAcceptConnect:
         self.engine = None
         self.server_sid = None
         self.accept_sid = None
-        self.client_addr = None
-        self.client_port = None
+        self.accept_addr = None
+        self.accept_port = None
     def __repr__(self):
         return '(%s%s)'%(self.__class__.__name__, '|'.join([str(x) for x in
-            [self.engine, self.server_sid, self.accept_sid, self.client_addr, self.client_port]]))
+            [self.engine, self.server_sid, self.accept_sid, self.accept_addr, self.accept_port]]))
 
 class CsTcpAcceptCondrop:
     "Fired when a TCP server has accepted a client connection."

--- a/solent/eng/engine.py
+++ b/solent/eng/engine.py
@@ -141,25 +141,29 @@ class Engine(object):
                 traceback.print_exc()
         for orb in self.spins.values():
             try:
-                orb.at_close()
+                orb.eng_close()
             except:
                 traceback.print_exc()
     def _add_spin(self, spin_h, spin):
-        at_methods = [m for m in dir(spin) if m.startswith('at_')]
-        m = "Missing method. Spins need at_turn(drive) and at_close()."
-        if 'at_turn' not in at_methods:
+        eng_methods = [m for m in dir(spin) if m.startswith('eng_')]
+        m = "Missing method. Need eng_turn(activity), eng_close()"
+        if 'eng_turn' not in eng_methods:
             raise Exception(m)
-        if 'at_close' not in at_methods:
+        if 'eng_close' not in eng_methods:
             raise Exception(m)
         if spin_h in self.spins:
             raise Exception("Engine already has spin_h %s"%spin_h)
         if spin in self.spins.values():
             raise Exception("Orb is already in engine. Don't double-add.")
         self.spins[spin_h] = spin
-    def init_orb(self, spin_h, i_nearcast):
+    def init_orb(self, i_nearcast):
         '''
         Orb is a special kind of spin that does nearcasting.
         '''
+        # The orb has a method for changing this. It was a hassle and likely
+        # confusing to new users to force the user to be constantly changing
+        # this. Hence, we default it.
+        spin_h = 'orb/%s'%(uniq())
         spin = orb_new(
             spin_h=spin_h,
             engine=self,
@@ -187,7 +191,7 @@ class Engine(object):
         # Caller's callback
         orbs_in_this_loop = list(self.spins.values())
         for orb in orbs_in_this_loop:
-            orb.at_turn(
+            orb.eng_turn(
                 activity=self.activity)
         lst_orb_activity = self.activity.get()
         if lst_orb_activity:
@@ -494,7 +498,7 @@ class Engine(object):
     def _close_metasock(self, sid, reason):
         ms = self._get_ms_for_sid(
             sid=sid)
-        ms.close(reason)
+        ms.eng_close(reason)
         del self.sid_to_metasock[sid]
         #
         # If we are in the middle of a select loop, there is a mechanism

--- a/solent/eng/metasock.py
+++ b/solent/eng/metasock.py
@@ -178,8 +178,8 @@ class Metasock(object):
             self.cs_tcp_accept_connect.engine = self.engine
             self.cs_tcp_accept_connect.server_sid = self.parent_sid
             self.cs_tcp_accept_connect.accept_sid = self.sid
-            self.cs_tcp_accept_connect.client_addr = self.addr
-            self.cs_tcp_accept_connect.client_port = self.port
+            self.cs_tcp_accept_connect.accept_addr = self.addr
+            self.cs_tcp_accept_connect.accept_port = self.port
             self.cb_tcp_accept_connect(
                 cs_tcp_accept_connect=self.cs_tcp_accept_connect)
         elif self.ms_type == MS_TYPE_TCP_CLIENT:
@@ -197,7 +197,7 @@ class Metasock(object):
                 cs_tcp_server_start=self.cs_tcp_server_start)
         else:
             raise Exception('Algorithm exception. [%s]'%(self.ms_type))
-    def close(self, message):
+    def eng_close(self, message):
         '''
         Safely attempts to close the socket. This should be called from one
         place and one place only - engine._close_metasock. (It's tightly

--- a/solent/gruel/client/spin_gruel_client.py
+++ b/solent/gruel/client/spin_gruel_client.py
@@ -58,7 +58,8 @@ class SpinGruelClient:
         self.cb_doc = None
         self.doc_accumulator = None
         self.client_sid = None
-    def at_turn(self, activity):
+    #
+    def eng_turn(self, activity):
         #
         # heartbeat logic
         if self.status == ClientStatus.streaming:
@@ -78,13 +79,13 @@ class SpinGruelClient:
                 l=self,
                 s='processing outbound doc')
             self._send_docpart()
-    def at_close(self):
+    def eng_close(self):
         if None != self.client_sid:
             self.engine.close_client(
                 client_sid=self.client_sid)
+    #
     def send_document(self, doc):
         self.q_outbound_documents.append(doc)
-    #
     def get_status(self):
         '''
         Returns helpful messages that lets its parent class understand

--- a/solent/gruel/server/heartbeater_cog.py
+++ b/solent/gruel/server/heartbeater_cog.py
@@ -34,14 +34,7 @@ class HeartbeaterCog(object):
         #
         self.b_active = False
         self.t_last_heartbeat = None
-    #
-    def on_announce_login(self, max_packet_size, max_fulldoc_size):
-        self.b_active = True
-        self.t_last_heartbeat = self.engine.clock.now()
-    def on_announce_tcp_condrop(self):
-        self.b_active = False
-        self.t_last_heartbeat = None
-    def at_turn(self, activity):
+    def orb_turn(self, activity):
         if not self.b_active:
             return
         now = self.engine.clock.now()
@@ -53,6 +46,13 @@ class HeartbeaterCog(object):
                 cog=self,
                 message_h='heartbeat_send')
             self.t_last_heartbeat = now
+    #
+    def on_announce_login(self, max_packet_size, max_fulldoc_size):
+        self.b_active = True
+        self.t_last_heartbeat = self.engine.clock.now()
+    def on_announce_tcp_condrop(self):
+        self.b_active = False
+        self.t_last_heartbeat = None
 
 def heartbeater_cog_new(cog_h, orb, engine):
     ob = HeartbeaterCog(

--- a/solent/gruel/server/server_customs_cog.py
+++ b/solent/gruel/server/server_customs_cog.py
@@ -106,7 +106,7 @@ class ServerCustomsCog:
         self.nc_nearnote(
             s='clearing state')
     #
-    def at_turn(self, activity):
+    def orb_turn(self, activity):
         if self.state == ServerCustomsState.reject_stage_a:
             # We sit on a plan to reject for several seconds. this
             # prevents users from spamming us with bad logons. After
@@ -146,6 +146,7 @@ class ServerCustomsCog:
                     bb=self.gruel_press.create_docdata_bb(
                         data=bb,
                         b_complete=b_complete))
+    #
     def on_announce_tcp_connect(self, ip, port):
         self._zero()
     def on_announce_tcp_condrop(self):

--- a/solent/gruel/server/spin_gruel_server.py
+++ b/solent/gruel/server/spin_gruel_server.py
@@ -76,14 +76,14 @@ class UplinkCog:
             message_h='stop_service')
 
 class SpinGruelServer:
-    def __init__(self, engine, cb_doc_recv):
+    def __init__(self, spin_h, engine, cb_doc_recv):
+        self.spin_h = spin_h
         self.engine = engine
         self.cb_doc_recv = cb_doc_recv
         #
         self.b_active = False
         #
         self.orb = engine.init_orb(
-            spin_h=__name__,
             i_nearcast=I_NEARCAST_GRUEL_SERVER)
         self.orb.add_log_snoop()
         #
@@ -98,9 +98,10 @@ class SpinGruelServer:
         #
         self.uplink.nc_nearnote(
             s='spin_gruel_server: nearcast_started')
-    def at_turn(self, activity):
-        self.orb.at_turn(
-            activity=activity)
+    def eng_turn(self, activity):
+        pass
+    def eng_close(self):
+        pass
     #
     def get_status(self):
         return self.b_active
@@ -132,8 +133,9 @@ class SpinGruelServer:
         self.cb_doc_recv(
             doc=doc)
 
-def spin_gruel_server_new(engine, cb_doc_recv):
+def spin_gruel_server_new(spin_h, engine, cb_doc_recv):
     ob = SpinGruelServer(
+        spin_h=spin_h,
         engine=engine,
         cb_doc_recv=cb_doc_recv)
     return ob

--- a/solent/gruel/server/tcp_server_cog.py
+++ b/solent/gruel/server/tcp_server_cog.py
@@ -46,9 +46,7 @@ class TcpServerCog:
         #
         self.server_addr = None
         self.server_port = None
-    def at_turn(self, activity):
-        pass
-    def at_close(self):
+    def orb_close(self):
         self.close_everything()
     #
     def on_start_service(self, ip, port, password):
@@ -66,7 +64,6 @@ class TcpServerCog:
         self.close_everything()
     def on_please_tcp_boot(self):
         self._boot_any_accept()
-        # at_turn will take care of bringing the server back
     def on_gruel_send(self, bb):
         if not self.accept_sid:
             return
@@ -87,12 +84,12 @@ class TcpServerCog:
         engine = cs_tcp_accept_connect.engine
         server_sid = cs_tcp_accept_connect.server_sid
         accept_sid = cs_tcp_accept_connect.accept_sid
-        client_addr = cs_tcp_accept_connect.client_addr
-        client_port = cs_tcp_accept_connect.client_port
+        accept_addr = cs_tcp_accept_connect.accept_addr
+        accept_port = cs_tcp_accept_connect.accept_port
         #
         self.nearcast.announce_tcp_connect(
-            ip=client_addr,
-            port=client_port)
+            ip=accept_addr,
+            port=accept_port)
         self.accept_sid = accept_sid
         self._boot_any_server()
     def _engine_on_tcp_accept_condrop(self, cs_tcp_accept_condrop):

--- a/solent/lc/cs.py
+++ b/solent/lc/cs.py
@@ -1,0 +1,34 @@
+#
+# callback structures for module lc
+#
+# // license
+# Copyright 2016, Free Software Foundation.
+#
+# This file is part of Solent.
+#
+# Solent is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# Solent is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# Solent. If not, see <http://www.gnu.org/licenses/>.
+
+class CsLcConnect:
+    def __init__(self):
+        self.addr = None
+        self.port = None
+
+class CsLcCondrop:
+    def __init__(self):
+        self.msg = None
+
+class CsLcCommand:
+    def __init__(self):
+        self.tokens = None
+

--- a/solent/log/liblog.py
+++ b/solent/log/liblog.py
@@ -177,6 +177,7 @@ def hexdump_bytes(arr, title='hexdump'):
     print('// %s [%s bytes]'%(title, arr_len))
     #
     # Main content
+    idx = 0
     for (idx, b) in enumerate(arr):
         print('%02x'%(b), end=' ')
         if b >= ord(' ') and b <= ord('~'):

--- a/solent/redis/spin_redis_client.py
+++ b/solent/redis/spin_redis_client.py
@@ -28,9 +28,9 @@ class SpinRedisClient:
         self.cb_ex_redis = cb_ex_redis
         #
         self.client_sid = None
-    def at_turn(self, activity):
+    def eng_turn(self, activity):
         pass
-    def at_close(self):
+    def eng_close(self):
         pass
     #
     def start(self, ip, port):

--- a/solent/release/roguebox_00_weed_the_garden.py
+++ b/solent/release/roguebox_00_weed_the_garden.py
@@ -331,10 +331,6 @@ class CogTerm:
         self.orb = orb
         #
         self.spin_term = None
-    def at_turn(self, activity):
-        self.spin_term.at_turn(
-            activity=activity)
-    #
     def on_init(self, console_type, console_height, console_width):
         self.spin_term = self.engine.init_spin(
             construct=spin_term_new,
@@ -449,7 +445,7 @@ class CogRoguebox:
         self.b_game_started = False
         self.b_mail_waiting = False
         self.b_refresh_needed = False
-    def at_turn(self, activity):
+    def orb_turn(self, activity):
         if None == self.spin_roguelike:
             return
         if not self.track_containment_mode.is_focus_on_game():
@@ -590,7 +586,6 @@ def game(console_type):
         #engine.debug_eloop_on()
         #
         orb = engine.init_orb(
-            spin_h=__name__,
             i_nearcast=I_CONTAINMENT_NEARCAST_SCHEMA)
         #orb.add_log_snoop()
         orb.init_cog(CogInterpreter)

--- a/solent/release/snake.py
+++ b/solent/release/snake.py
@@ -385,11 +385,6 @@ class CogTerm:
         self.orb = orb
         #
         self.spin_term = None
-    def at_turn(self, activity):
-        if None == self.spin_term:
-            return
-        self.spin_term.at_turn(
-            activity=activity)
     #
     def on_init(self, console_type, height, width):
         self.spin_term = self.engine.init_spin(
@@ -495,7 +490,7 @@ class CogSnakeGame:
         self.width = None
         self.spin_snake_game = None
         self.tick_t100 = None
-    def at_turn(self, activity):
+    def orb_turn(self, activity):
         if self.spin_snake_game == None:
             return
         if not self.track_containment_mode.is_focus_on_game():
@@ -565,8 +560,8 @@ def game(console_type):
         engine.default_timeout = 0.01
         #
         orb = engine.init_orb(
-            spin_h=__name__,
             i_nearcast=I_CONTAINMENT_NEARCAST_SCHEMA)
+        orb.add_log_snoop()
         orb.init_cog(CogInterpreter)
         orb.init_cog(CogTerm)
         orb.init_cog(CogMenu)

--- a/solent/rogue/simple_00_weed_the_garden/spin_simple.py
+++ b/solent/rogue/simple_00_weed_the_garden/spin_simple.py
@@ -128,8 +128,8 @@ class SpinSimple:
 
     def _init_orb(self):
         self.orb = self.engine.init_orb(
-            spin_h='swamp_monster_orb',
             i_nearcast=I_NEARCAST)
+        self.orb.set_spin_h('swamp_monster_orb')
         #self.orb.add_log_snoop()
 
     def get_supported_directives(self):

--- a/solent/rogue/simple_01_coordinates_and_ecs/spin_simple.py
+++ b/solent/rogue/simple_01_coordinates_and_ecs/spin_simple.py
@@ -128,8 +128,8 @@ class SpinSimple:
 
     def _init_orb(self):
         self.orb = self.engine.init_orb(
-            spin_h='swamp_monster_orb',
             i_nearcast=I_NEARCAST)
+        self.orb.set_spin_h('swamp_monster_orb')
         #self.orb.add_log_snoop()
 
     def get_supported_directives(self):

--- a/solent/rogue/swamp_monster/spin_swamp_monster.py
+++ b/solent/rogue/swamp_monster/spin_swamp_monster.py
@@ -305,7 +305,7 @@ class CogWorld:
         self.chart_buffer_prev = None
         #
         self.need_to_update_display = False
-    def at_turn(self, activity):
+    def orb_turn(self, activity):
         if self.need_to_update_display:
             activity.mark(
                 l=self,
@@ -442,7 +442,7 @@ class CogPlayer:
         self.pin_meeps = orb.init_pin(PinMeeps)
         self.q_input = deque()
         self.sent_need_input = False
-    def at_turn(self, activity):
+    def orb_turn(self, activity):
         if self.q_input:
             activity.mark(
                 l=self,
@@ -545,8 +545,8 @@ class SpinSwampMonster:
         self.cb_log = cb_log
         #
         self.orb = self.engine.init_orb(
-            spin_h='swamp_monster_orb',
             i_nearcast=I_NEARCAST)
+        self.orb.set_spin_h('swamp_monster_orb')
         self.orb.add_log_snoop()
         self.orb.init_cog(CogWorld)
         self.orb.init_cog(CogLadyOfTheLake)

--- a/solent/term/spin_term.py
+++ b/solent/term/spin_term.py
@@ -65,7 +65,8 @@ class SpinTerm:
         self.select_cgrid = None
         #
         self.lmousedown_coords = None
-    def at_turn(self, activity):
+    #
+    def eng_turn(self, activity):
         if self.mode == MODE_NONE:
             return
         #
@@ -86,7 +87,7 @@ class SpinTerm:
                 keycode=keycode)
         #
         self.refresh_console()
-    def at_close(self):
+    def eng_close(self):
         if None != self.console:
             self.console.close()
     #

--- a/solent/tools/qd_poll.py
+++ b/solent/tools/qd_poll.py
@@ -54,7 +54,7 @@ class CogUdpSender:
         #
         self.pub_sid = None
         self.t_last = None
-    def at_turn(self, activity):
+    def orb_turn(self, activity):
         if self.pub_sid == None:
             return
         now = time.time()
@@ -64,10 +64,11 @@ class CogUdpSender:
             self.engine.send(
                 sid=self.pub_sid,
                 bb=bytes('message at [%s]\n'%now, 'utf8'))
-    def at_close(self):
+    def orb_close(self):
         self.engine.close_broadcast_listener(
             sid=self.pub_sid)
         self.pub_sid = None
+    #
     def on_init(self, addr, port):
         self.engine.open_pub(
             addr=addr,
@@ -111,7 +112,6 @@ def main():
         net_port = int(sys.argv[2])
         #
         orb = engine.init_orb(
-            spin_h=__name__,
             i_nearcast=I_NEARCAST_SCHEMA)
         orb.init_cog(CogUdpSender)
         bridge = orb.init_cog(CogBridge)

--- a/solent/tools/tclient.py
+++ b/solent/tools/tclient.py
@@ -69,12 +69,11 @@ class CogTcpClient:
         self.engine = engine
         #
         self.client_sid = None
-    def at_close(self):
-        self.engine.close_tcp_client(
-            client_sid=self.client_sid)
-    def at_turn(self, activity):
-        if self.client_sid == None:
-            return
+    def orb_close(self):
+        if None != self.client_sid:
+            self.engine.close_tcp_client(
+                client_sid=self.client_sid)
+    #
     def on_init(self, addr, port):
         self.engine.open_tcp_client(
             addr=addr,
@@ -121,12 +120,7 @@ class CogTerm:
         self.line_finder = None
         self.drop = None
         self.rest = None
-    def at_close(self):
-        pass
-    def at_turn(self, activity):
-        if None != self.spin_term:
-            self.spin_term.at_turn(
-                activity=activity)
+    #
     def on_init(self, addr, port):
         self.spin_term = self.engine.init_spin(
             construct=spin_term_new,
@@ -253,7 +247,6 @@ def main():
         net_port = int(sys.argv[2])
         #
         orb = engine.init_orb(
-            spin_h=__name__,
             i_nearcast=I_NEARCAST_SCHEMA)
         orb.add_log_snoop()
         orb.init_cog(CogTcpClient)

--- a/testing/eng/orb.py
+++ b/testing/eng/orb.py
@@ -48,7 +48,6 @@ I_NEARCAST_EXAMPLE = '''
 def should_construct():
     engine = fake_engine_new()
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_EXAMPLE)
     #
     return True

--- a/testing/gruel/client/spin_gruel_client.py
+++ b/testing/gruel/client/spin_gruel_client.py
@@ -71,9 +71,10 @@ class SpinReneGruelServer:
         self.accept_sid = None
         self.server_sid = None
         self.received_message_ds = None
-    def at_turn(self, activity):
+    #
+    def eng_turn(self, activity):
         pass
-    def at_close(self):
+    def eng_close(self):
         self._close_everything()
     #
     def is_server_listening(self):
@@ -143,8 +144,8 @@ class SpinReneGruelServer:
         engine = cs_tcp_accept_connect.engine
         server_sid = cs_tcp_accept_connect.server_sid
         accept_sid = cs_tcp_accept_connect.accept_sid
-        client_addr = cs_tcp_accept_connect.client_addr
-        client_port = cs_tcp_accept_connect.client_port
+        accept_addr = cs_tcp_accept_connect.accept_addr
+        accept_port = cs_tcp_accept_connect.accept_port
         #
         self.accept_sid = accept_sid
         self.received_message_ds = []

--- a/testing/gruel/server/heartbeater_cog.py
+++ b/testing/gruel/server/heartbeater_cog.py
@@ -23,7 +23,6 @@ from fake.eng import fake_engine_new
 
 from testing import run_tests
 from testing import test
-from testing.gruel.server.receiver_cog import receiver_cog_fake
 
 from solent import uniq
 from solent.eng import activity_new
@@ -55,12 +54,10 @@ def should_start_on_announce_login_and_stop_on_announce_condrop():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     heartbeater_cog = orb.init_cog(
         construct=heartbeater_cog_new)
-    r = orb.init_cog(
-        construct=receiver_cog_fake)
+    r = orb.init_test_bridge_cog()
     #
     # check starting assumptions
     assert 0 == r.count_heartbeat_send()

--- a/testing/gruel/server/ipval_cog.py
+++ b/testing/gruel/server/ipval_cog.py
@@ -42,7 +42,6 @@ import sys
 def should_reject_unauthorised_ip():
     engine = fake_engine_new()
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     r = orb.init_cog(
         construct=receiver_cog_fake)
@@ -65,7 +64,6 @@ def should_reject_unauthorised_ip():
 def should_allow_authorised_ip():
     engine = fake_engine_new()
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     r = orb.init_cog(
         construct=receiver_cog_fake)
@@ -105,7 +103,6 @@ def should_allow_authorised_ip():
 def should_allow_any_ip():
     engine = fake_engine_new()
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     r = orb.init_cog(
         construct=receiver_cog_fake)

--- a/testing/gruel/server/receiver_cog.py
+++ b/testing/gruel/server/receiver_cog.py
@@ -5,6 +5,8 @@
 # Cog that sits on the nearcast with methods that make it useful for testing
 # scenarios.
 #
+# xxx needs to be obsoleted in favour of the standard orb approach.
+#
 # // license
 # Copyright 2016, Free Software Foundation.
 #

--- a/testing/gruel/server/server_customs_cog.py
+++ b/testing/gruel/server/server_customs_cog.py
@@ -53,7 +53,6 @@ def should_throw_alg_exception_if_packet_seen_before_password():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     server_customs_cog = orb.init_cog(
         construct=server_customs_cog_new)
@@ -86,7 +85,6 @@ def should_store_password_values():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     server_customs_cog = orb.init_cog(
         construct=server_customs_cog_new)
@@ -118,7 +116,6 @@ def should_boot_client_if_first_message_is_not_client_login():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     server_customs_cog = orb.init_cog(
         construct=server_customs_cog_new)
@@ -159,7 +156,6 @@ def should_boot_user_on_receipt_of_login_message_when_already_logged_in():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     server_customs_cog = orb.init_cog(
         construct=server_customs_cog_new)
@@ -202,7 +198,6 @@ def should_do_basic_login_reject():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     server_customs_cog = orb.init_cog(
         construct=server_customs_cog_new)
@@ -247,7 +242,6 @@ def should_do_successful_login_accept():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     server_customs_cog = orb.init_cog(
         construct=server_customs_cog_new)
@@ -291,7 +285,6 @@ def should_run_a_rejection_sequence():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     server_customs_cog = orb.init_cog(
         construct=server_customs_cog_new)
@@ -346,7 +339,6 @@ def should_clear_state_in_announce_connect():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     server_customs_cog = orb.init_cog(
         construct=server_customs_cog_new)
@@ -376,7 +368,6 @@ def should_buffer_a_couple_of_docs():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     server_customs_cog = orb.init_cog(
         construct=server_customs_cog_new)
@@ -451,7 +442,6 @@ def should_send_a_couple_of_docs():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     server_customs_cog = orb.init_cog(
         construct=server_customs_cog_new)
@@ -517,7 +507,6 @@ def should_convert_heartbeat_requests_to_gruel():
         mtu=engine.mtu)
     #
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     server_customs_cog = orb.init_cog(
         construct=server_customs_cog_new)

--- a/testing/gruel/server/spin_gruel_server.py
+++ b/testing/gruel/server/spin_gruel_server.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License along with
 # Solent. If not, see <http://www.gnu.org/licenses/>.
 
-from fake.eng import fake_engine_new
+from solent.eng import engine_new
 
 from testing import run_tests
 from testing import test
@@ -60,7 +60,8 @@ def should_construct_and_start_and_stop():
         orb=None,
         engine=None)
     #
-    engine = fake_engine_new()
+    engine = engine_new(
+        mtu=MTU)
     activity = activity_new()
     #
     # scenario: construction
@@ -71,8 +72,8 @@ def should_construct_and_start_and_stop():
     gruel_puff = gruel_puff_new(
         gruel_protocol=gruel_protocol,
         mtu=MTU)
-    spin_gruel_server = spin_gruel_server_new(
-        engine=engine,
+    spin_gruel_server = engine.init_spin(
+        construct=spin_gruel_server_new,
         cb_doc_recv=r.on_doc_recv)
     #
     # scenario: start and stop without crashing

--- a/testing/gruel/server/tcp_server_cog.py
+++ b/testing/gruel/server/tcp_server_cog.py
@@ -64,9 +64,9 @@ class SpinReneClient:
         self.client_sid = None
         self.b_have_received_something = None
         self.sb_recv = None
-    def at_turn(self, activity):
+    def eng_turn(self, activity):
         pass
-    def at_close(self):
+    def eng_close(self):
         pass
     #
     def _engine_on_tcp_client_connect(self, cs_tcp_client_connect):
@@ -158,7 +158,6 @@ def should_start_and_stop():
     engine = engine_new(
         mtu=MTU)
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     bridge = orb.init_test_bridge_cog()
     tcp_server_cog = orb.init_cog(
@@ -199,7 +198,6 @@ def should_handle_client_connect_and_then_boot_client():
     engine = engine_new(
         mtu=MTU)
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     bridge = orb.init_test_bridge_cog()
     tcp_server_cog = orb.init_cog(
@@ -253,7 +251,6 @@ def should_broadcast_incoming_message_as_gruel_in():
     engine = engine_new(
         mtu=MTU)
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     #
     bridge = orb.init_test_bridge_cog()
@@ -321,7 +318,6 @@ def should_boot_client_when_told_to():
     engine = engine_new(
         mtu=MTU)
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     #
     bridge = orb.init_test_bridge_cog()
@@ -371,7 +367,6 @@ def should_boot_client_when_invalid_gruel_is_received():
     engine = engine_new(
         mtu=MTU)
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     #
     bridge = orb.init_test_bridge_cog()
@@ -431,7 +426,6 @@ def should_ignore_gruel_send_when_no_client():
     engine = engine_new(
         mtu=MTU)
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     bridge = orb.init_test_bridge_cog()
     tcp_server_cog = orb.init_cog(
@@ -508,7 +502,6 @@ def should_send_gruel_send_data_to_a_connected_client():
     engine = engine_new(
         mtu=MTU)
     orb = engine.init_orb(
-        spin_h='app',
         i_nearcast=I_NEARCAST_GRUEL_SERVER)
     bridge = orb.init_test_bridge_cog()
     tcp_server_cog = orb.init_cog(
@@ -535,8 +528,6 @@ def should_send_gruel_send_data_to_a_connected_client():
     assert False == tcp_server_cog.is_accept_connected()
     #
     # scenario: client connects
-    client_addr = '203.15.93.150'
-    client_port = 6000
     rene = engine.init_spin(
         construct=spin_rene_client_new)
     rene.init()


### PR DESCRIPTION
(1) Significant API changes. Engine events to spins now go to eng_turn, eng_close rather than at_turn, at_close. Similarly, Orb events now go to orb_turn, orb_close, not weird at_turn,close combination from before.

(2) Significant change to API of spin line console so that it is now following the callback convention.

(3) engine.init_orb no longer requires a spin_h argument. You can set it against the orb, but it was a distraction for normal use-cases. Hence, it is gone.
